### PR TITLE
Fixed issue #3 with state and hover events.

### DIFF
--- a/src/components/MainBody.jsx
+++ b/src/components/MainBody.jsx
@@ -52,10 +52,10 @@ class MainBody extends Component {
                     className={`fab ${icon.image}  fa-3x ${
                       this.state.hoverstatus[icon.id]
                     }`}
-                    onMouseEnter={() =>
+                    onMouseOver={() =>
                       this.toggleHover({ icon: icon, event: "enter" })
                     }
-                    onMouseLeave={() =>
+                    onMouseOut={() =>
                       this.toggleHover({ icon: icon, event: "leave" })
                     }
                   />


### PR DESCRIPTION
Hi,

I recently came across your portfolio in my GitHub feed.
I have reproduced and solved the issue with icons retaining their black or hovered state when mousing between multiple icons. I traced the issue down to the events you were binding icons' states to, causing bubbling.
You can read more about that [here on Stack Overflow](https://stackoverflow.com/questions/1638877/difference-between-onmouseover-and-onmouseenter).

Cheers,
Cody

closes #3 