### PR TITLE
#32 Edit instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ You should have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/
 
 ## Setup And Deployment 🔧
 
-1. To Get Started, Fork this repository to your GitHub account:
+1. To Get Started, create a new repository with name \<your-username>.github.io
+1. Fork this repository to your GitHub account:
 2. Clone the forked repo from your account using:
 
    ```bash
@@ -91,13 +92,15 @@ You should have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/
 5. Change URL in [package.json](./package.json) file:
 
    ```json
-   "homepage": "https://<your-username>.github.io/home"
+   "homepage": "https://<your-username>.github.io"
    ```
 
-   Or for custom deployment, refer [create-react-app.dev](https://create-react-app.dev/docs/deployment/)
+6. You must now change the [pages.js](./pages.js#L3)
+```js
+const repoURL = "https://github.com/<your-username>/<your-username>.github.io.git";
+```
 
 6. Edit [title](./public/index.html#L34) and meta [description](./public/index.html#L13) in [public/index.html](./public/index.html).
-
 7. After editing run the following bash commands:
 
    ```bash
@@ -109,20 +112,14 @@ You should have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/
 
    ```bash
     npm run build
-    npm run deploy
-   ```
-
-   Or for custom deployment, refer [pages.js](./pages.js)
-
-   ```bash
-    npm run build
     npm run custom-deploy
    ```
+
 
 9. Congrats your site is up and running. To see it live, visit:
 
    ```https
-     https://<your-username>.github.io/home
+     https://<your-username>.github.io/
    ```
 
 Facing issues? Feel free to contact at hashirshoaeb@gmail.com.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ You should have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/
 
 ## Setup And Deployment 🔧
 
-1. To Get Started, create a new repository with name \<your-username>.github.io
-1. Fork this repository to your GitHub account:
+1. To Get Started, Fork this repository to your GitHub account:
 2. Clone the forked repo from your account using:
 
    ```bash
@@ -92,15 +91,13 @@ You should have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/
 5. Change URL in [package.json](./package.json) file:
 
    ```json
-   "homepage": "https://<your-username>.github.io"
+   "homepage": "https://<your-username>.github.io/home"
    ```
 
-6. You must now change the [pages.js](./pages.js#L3)
-```js
-const repoURL = "https://github.com/<your-username>/<your-username>.github.io.git";
-```
+   Or for custom deployment, refer [create-react-app.dev](https://create-react-app.dev/docs/deployment/)
 
 6. Edit [title](./public/index.html#L34) and meta [description](./public/index.html#L13) in [public/index.html](./public/index.html).
+
 7. After editing run the following bash commands:
 
    ```bash
@@ -112,14 +109,20 @@ const repoURL = "https://github.com/<your-username>/<your-username>.github.io.gi
 
    ```bash
     npm run build
-    npm run custom-deploy
+    npm run deploy
    ```
 
+   Or for custom deployment, refer [pages.js](./pages.js)
+
+   ```bash
+    npm run build
+    npm run custom-deploy
+   ```
 
 9. Congrats your site is up and running. To see it live, visit:
 
    ```https
-     https://<your-username>.github.io/
+     https://<your-username>.github.io/home
    ```
 
 Facing issues? Feel free to contact at hashirshoaeb@gmail.com.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You should have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/
     npm run deploy
    ```
 
-   Or for custom deployment, refer [pages.js](./pages.js)
+  Or for custom deployment, refer [READMEdocs/custom-deployment.md](./READMEdocs/custom-deployment.md) and [pages.js](./pages.js)
 
    ```bash
     npm run build

--- a/READMEdocs/custom-deployment.md
+++ b/READMEdocs/custom-deployment.md
@@ -1,0 +1,43 @@
+## Setup And Custom-Deployment 🔧
+
+1. To Get Started, create a new repository named \<your-username>.github.io
+1.  Fork this repository to your GitHub account:
+2. Clone the forked repo from your account using:
+
+   ```bash
+     git clone https://github.com/<your-username>/home.git
+   ```
+
+3. Open in editor and edit [src/editable-stuff/configurations.json](./src/editable-stuff/configurations.json) file.
+
+4. Add your resume as <resume.pdf> in place of [src/editable-stuff/resume.pdf](./src/editable-stuff/)
+5. Change URL in [package.json](./package.json) file:
+
+   ```json
+   "homepage": "https://<your-username>.github.io"
+   ```
+
+6. Now you need to go to [pages.js](../pages.js#L3)
+There you must now change the 3rd line to:
+
+```js
+const repoURL = "https://github.com/<your-username>/<your-username>.github.io.git";
+```
+
+6. Edit [title](./public/index.html#L34) and meta [description](./public/index.html#L13) in [public/index.html](./public/index.html).
+
+
+8. To deploy website run:
+
+   ```bash
+    npm run build
+    npm run custom-deploy
+   ```
+
+9. Congrats your site is up and running. To see it live, visit:
+
+   ```https
+     https://<your-username>.github.io
+   ```
+
+Facing issues? Feel free to contact at hashirshoaeb@gmail.com.


### PR DESCRIPTION
To deploy the website on \<username>.github.io instead of \<username>.github.io/home/

Since many developers want to deploy their website on the user site instead of a project site. This commit will help change that. This solves issue #32 