### PR TITLE
Fixed empty description skeleton issue

### DIFF
--- a/src/components/home/ProjectCard.jsx
+++ b/src/components/home/ProjectCard.jsx
@@ -18,7 +18,7 @@ const ProjectCard = ({ value }) => {
       <Card className="card shadow-lg p-3 mb-5 bg-white rounded">
         <Card.Body>
           <Card.Title as="h5">{name || <Skeleton />} </Card.Title>
-          <Card.Text>{description || <Skeleton count={3} />} </Card.Text>
+          <Card.Text>{(!description)?"":description || <Skeleton count={3} />} </Card.Text>
           {svn_url ? <CardButtons svn_url={svn_url} /> : <Skeleton count={2} />}
           <hr />
           {languages_url ? (


### PR DESCRIPTION
Fixed the ProjectCard for projects with empty description
<img width="593" alt="Screenshot 2021-02-02 at 1 04 13 PM" src="https://user-images.githubusercontent.com/49650773/106569056-18a72000-655a-11eb-8780-ab4cbfbd8747.png">
